### PR TITLE
Added PCL in CMakeLists so we can build PCL projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,5 +3,12 @@ project(3DCopy)
 
 set(CMAKE_CXX_STANDARD 11)
 
+find_package(PCL 1.3 REQUIRED)
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+
 set(SOURCE_FILES src/main.cpp src/Cli.cpp)
 add_executable(3DCopy ${SOURCE_FILES})
+
+target_link_libraries(3DCopy ${PCL_COMMON_LIBRARIES} ${PCL_IO_LIBRARIES})


### PR DESCRIPTION
La till PCL i CMakeLists så det går att bygga med PCL så behöver inte alla sitta och krångla med det själva. Så länge PCL är installerat på datorn borde det fungera att bara inkludera rätt pcl-headers och bygga.