### PR TITLE
Auto detection av mappar

### DIFF
--- a/include/Cli.h
+++ b/include/Cli.h
@@ -10,7 +10,7 @@
 #ifndef INC_3DCOPY_CLI_H
 #define INC_3DCOPY_CLI_H
 
-typedef boost::filesystem::path Path;
+namespace fs = boost::filesystem;
 
 class Cli {
     public:
@@ -20,7 +20,7 @@ class Cli {
 
     private:
         // Fields
-        std::vector<Path> sources;
+        std::vector<fs::path> sources;
         std::string output_filename;
         bool source_is_dir;
         bool mesh_only;
@@ -29,9 +29,9 @@ class Cli {
         // Methods
         int parse_arguments(int argc, char* argv[]);
         int parse_option(std::string option);
-        int read_dir(std::string path);
+        int read_dir(fs::path path);
         void print_input();
-        bool is_pcd_file(std::string filename);
+        void add_source(fs::path path);
         pcl::PointCloud<pcl::PointXYZ>::Ptr register_point_clouds();
         void save_point_cloud(const pcl::PointCloud<pcl::PointXYZ>::Ptr point_cloud);
         void save_mesh(const pcl::PolygonMesh polygon_mesh);

--- a/include/Cli.h
+++ b/include/Cli.h
@@ -22,9 +22,9 @@ class Cli {
         // Fields
         std::vector<fs::path> sources;
         std::string output_filename;
-        bool source_is_dir;
         bool mesh_only;
         bool register_only;
+        bool verbose;
 
         // Methods
         int parse_arguments(int argc, char* argv[]);

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -37,6 +37,7 @@ int Cli::main(int argc, char **argv) {
                 "files." << std::endl;
         std::cout << "-m        just mesh the point cloud (only meshes the first point cloud)." << std::endl;
         std::cout << "-r        just registers the given point clouds, skips meshing." << std::endl;
+        std::cout << "-v        Verbose, makes the program tell you more about what it is doing." << std::endl;
         return 0;
     }
 

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -8,6 +8,7 @@
 #include <pcl/io/vtk_lib_io.h>
 
 typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
+namespace fs = boost::filesystem;
 
 /**
  *  Default constructor that initializes a few private values.
@@ -16,7 +17,7 @@ Cli::Cli() {
     source_is_dir = false;
     mesh_only = false;
     register_only = false;
-    sources = std::vector<Path>();
+    sources = std::vector<fs::path>();
 }
 
 /**
@@ -34,7 +35,6 @@ int Cli::main(int argc, char **argv) {
         std::cout << "Usage: " << argv[0] << " [options] source1:source2... output_filename" << std::endl;
         std::cout << "source are the .pcd files to be registered and output_filename is the filename of the output "
                 "files." << std::endl;
-        std::cout << "-d        source is a directory with the .pcd files." << std::endl;
         std::cout << "-m        just mesh the point cloud (only meshes the first point cloud)." << std::endl;
         std::cout << "-r        just registers the given point clouds, skips meshing." << std::endl;
         return 0;
@@ -66,9 +66,7 @@ int Cli::main(int argc, char **argv) {
  */
 int Cli::parse_option(std::string option) {
 
-    if (option == "-d") {
-        source_is_dir = true;
-    } else if (option == "-m") {
+    if (option == "-m") {
         mesh_only = true;
         register_only = false;
     } else if (option == "-r") {
@@ -88,30 +86,27 @@ int Cli::parse_option(std::string option) {
  * @param dir path to the directory.
  * @return error code 0 if everything went ok non-zero otherwise.
  */
-int Cli::read_dir(std::string dir) {
+int Cli::read_dir(fs::path path) {
 
-    Path path = Path(dir);
+    if (!fs::exists(path)) {
+        std::cout << path << " not found." << std::endl;
+        return 1;
+    }
 
     try {
-        if (boost::filesystem::exists(path)) {
-            if (boost::filesystem::is_regular_file(path)) {
-                sources.push_back(path);
-                return 0;
-            } else if (boost::filesystem::is_directory(path)) {
-
-                boost::filesystem::directory_iterator it = boost::filesystem::directory_iterator(path);
-                boost::filesystem::directory_iterator end;
-                for (it; it != end; ++it) {
-                    if (is_pcd_file(it->path().string())) {
-                        sources.push_back(it->path());
-                    } else {
-                        std::cout << it->path() << " is not a pcd file." << std::endl;
-                    }
+        if (fs::is_directory(path)) {
+            fs::directory_iterator it = fs::directory_iterator(path);
+            fs::directory_iterator end;
+            for (it; it != end; ++it) {
+                if (fs::is_regular_file(it->path())) {
+                    add_source(it->path());
+                } else if (fs::is_directory(it->path())) {
+                    read_dir(it->path());
                 }
-
             }
+
         }
-    } catch (const boost::filesystem::filesystem_error& ex) {
+    } catch (const fs::filesystem_error& ex) {
         std::cout << ex.what() << std::endl;
         return 1;
     }
@@ -128,7 +123,7 @@ int Cli::read_dir(std::string dir) {
 int Cli::parse_arguments(int argc, char **argv) {
 
     // Make sure there is enough arguments
-    if (argc < 4) {
+    if (argc < 3) {
         std::cout << "To few arguments" << std::endl;
         return 1;
     }
@@ -147,25 +142,25 @@ int Cli::parse_arguments(int argc, char **argv) {
         argument = std::string(argv[counter]);
     }
 
-    //Read sources
-    if (source_is_dir) {
-        read_dir(argument);
-    } else {
-        while (counter < last) {
-            // Make sure it's a .pcd file
-            if (!is_pcd_file(argument)) {
-                std::cout << "All input files must be .pcd files" << std::endl;
-                return 3;
+
+    while (counter < last) {
+
+        fs::path p = fs::path(argument);
+
+        if (fs::exists(p)) {
+
+            if (fs::is_directory(p)) {
+                read_dir(p);
+            } else if (fs::is_regular_file(p)) {
+                add_source(p);
             }
-            Path path = Path(argument);
-            if (boost::filesystem::exists(path)) {
-                sources.push_back(path);
-            } else {
-                std::cout << "File not found: " << path << std::endl;
-            }
-            counter++;
-            argument = std::string(argv[counter]);
+
+        } else {
+            std::cout << p << " not found." << std::endl;
         }
+
+        counter++;
+        argument = std::string(argv[counter]);
     }
 
     if (sources.empty()) {
@@ -192,13 +187,16 @@ void Cli::print_input() {
     std::cout << "Output filename: " << output_filename << std::endl;
 }
 
-/**
- * Checks if a file is a pcd file by checking if the file ending is '.pcd'.
- * @param filename The file to be checked.
- * @return True if it is a pcd file false otherwise.
- */
-bool Cli::is_pcd_file(std::string filename) {
-    return filename.substr(filename.find_last_of(".") + 1) == "pcd";
+void Cli::add_source(fs::path path) {
+    if (fs::exists(path)) {
+        if (fs::extension(path) == ".pcd") {
+            sources.push_back(path);
+        } else {
+            std::cout << path << " not recognized as pcd file." << std::endl;
+        }
+    } else {
+        std::cout << path << " not found." << std::endl;
+    }
 }
 
 /**

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -100,8 +100,6 @@ int Cli::read_dir(fs::path path) {
             for (it; it != end; ++it) {
                 if (fs::is_regular_file(it->path())) {
                     add_source(it->path());
-                } else if (fs::is_directory(it->path())) {
-                    read_dir(it->path());
                 }
             }
 

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -14,9 +14,9 @@ namespace fs = boost::filesystem;
  *  Default constructor that initializes a few private values.
  */
 Cli::Cli() {
-    source_is_dir = false;
     mesh_only = false;
     register_only = false;
+    verbose = false;
     sources = std::vector<fs::path>();
 }
 
@@ -72,6 +72,8 @@ int Cli::parse_option(std::string option) {
     } else if (option == "-r") {
         register_only = true;
         mesh_only = false;
+    } else if (option == "-v") {
+        verbose = true;
     }
     else {
         return 1;
@@ -168,6 +170,10 @@ int Cli::parse_arguments(int argc, char **argv) {
 
     output_filename = std::string(argv[last]);
 
+    if (verbose) {
+        print_input();
+    }
+
     return 0;
 
 }
@@ -176,8 +182,7 @@ int Cli::parse_arguments(int argc, char **argv) {
  * Prints the local variables read in from the command line used for debugging and testing.
  */
 void Cli::print_input() {
-    std::cout << "Source is directory: " << source_is_dir << std::endl;
-    std::cout << "Sources:";
+    std::cout << "Read sources:";
     for (size_t i=0; i < sources.size(); i++) {
         std::cout << " " << sources.at(i);
     }
@@ -185,6 +190,10 @@ void Cli::print_input() {
     std::cout << "Output filename: " << output_filename << std::endl;
 }
 
+/**
+ * Adds a file to sources after it has made sure the file exists and is a pcd file.
+ * @param path The file path to be added to sources.
+ */
 void Cli::add_source(fs::path path) {
     if (fs::exists(path)) {
         if (fs::extension(path) == ".pcd") {


### PR DESCRIPTION
Nu behövs inte -d flaggan längre. Programmet känner av huruvida du har gett den en mapp eller fil och är det en mapp så läser den in alla pcd filer i mappen. Det finns också ett -v för verbose option som gör så att programmet printar alla sources den läst in. Huruvida användaren har valt verbose eller inte vore bra om mesh- och registreringsklasserna kunde ta in så man kan välja om man vill ha mycket prints eller inte. Jag har testat lite manuellt med hjälp av -v flaggan. Jag testa med lite olika pcd filer från stickan. 