### PR TITLE
Working registration! 

### DIFF
--- a/include/Registration.h
+++ b/include/Registration.h
@@ -10,21 +10,6 @@ class Registration {
 public:
     //Methods
     Cloud::Ptr register_point_clouds(std::vector<Cloud::Ptr> input_pclouds);
-
-private:
-    //Data fields
-    bool icp_converged;
-    double max_correspondence_distance = 15;
-    int max_iterations = 100;
-    double transformation_epsilon = 1e-3;
-    double euclidean_fitness = 1;
-    double ransac_rejection_threshold = 1;
-    bool verbose = false;
-
-
-    //Methods
-    Cloud::Ptr add_point_cloud_to_target(Cloud::Ptr target_cloud, Cloud::Ptr source_cloud);
-    bool has_converged();
     void set_max_iterations(int iter);
     int get_max_iterations();
     void set_max_correspondence_distance(double distance);
@@ -37,6 +22,22 @@ private:
     double get_ransac_threshold();
     void set_euclidean_fitness(double epsilon);
     double get_euclidean_fitness();
+
+private:
+    //Data fields
+    bool icp_converged;
+    double max_correspondence_distance = 15;    //How far the input pclouds start out
+    int max_iterations = 100;                   //Force the ICP Algorithm to stop after max_iterations;
+    double transformation_epsilon = 1e-7;       //How much ICP is allowed to move source in one iteration;
+    double euclidean_fitness = 1;               //Currently unused
+    double ransac_rejection_threshold = 1;      //Currently unused
+    bool verbose = false;
+
+
+    //Methods
+    Cloud::Ptr add_point_cloud_to_target(Cloud::Ptr target_cloud, Cloud::Ptr source_cloud);
+    bool has_converged();
+
 };
 
 

--- a/include/Registration.h
+++ b/include/Registration.h
@@ -18,10 +18,6 @@ public:
     double get_transformation_epsilon();
     void set_verbose_mode(bool mode);
     bool get_verbose_mode();
-    void set_ransac_threshold(double threshold);
-    double get_ransac_threshold();
-    void set_euclidean_fitness(double epsilon);
-    double get_euclidean_fitness();
 
 private:
     //Data fields
@@ -30,8 +26,6 @@ private:
                                                 // point a in cloud y
     int max_iterations = 100;                   //Force the ICP Algorithm to stop after max_iterations;
     double transformation_epsilon = 1e-7;       //How much ICP is allowed to move source in one iteration;
-    double euclidean_fitness = 1;               //Currently unused
-    double ransac_rejection_threshold = 1;      //Currently unused
     bool verbose = false;
 
 

--- a/include/Registration.h
+++ b/include/Registration.h
@@ -26,7 +26,8 @@ public:
 private:
     //Data fields
     bool icp_converged;
-    double max_correspondence_distance = 15;    //How far the input pclouds start out
+    double max_correspondence_distance = 15;    //Maximum distance allowed between point a in cloud x and
+                                                // point a in cloud y
     int max_iterations = 100;                   //Force the ICP Algorithm to stop after max_iterations;
     double transformation_epsilon = 1e-7;       //How much ICP is allowed to move source in one iteration;
     double euclidean_fitness = 1;               //Currently unused

--- a/src/Registration.cpp
+++ b/src/Registration.cpp
@@ -46,8 +46,6 @@ Registration::add_point_cloud_to_target(Cloud::Ptr target_cloud, Cloud::Ptr sour
     icp.setMaximumIterations(this->max_iterations);
     icp.setTransformationEpsilon(this->transformation_epsilon);
     icp.setMaxCorrespondenceDistance(this->max_correspondence_distance);
-    //icp.setEuclideanFitnessEpsilon(this->euclidean_fitness);
-    //icp.setRANSACOutlierRejectionThreshold(this->ransac_rejection_threshold);
 
     icp.align(*target_cloud);
 

--- a/src/Registration.cpp
+++ b/src/Registration.cpp
@@ -46,8 +46,8 @@ Registration::add_point_cloud_to_target(Cloud::Ptr target_cloud, Cloud::Ptr sour
     icp.setMaximumIterations(this->max_iterations);
     icp.setTransformationEpsilon(this->transformation_epsilon);
     icp.setMaxCorrespondenceDistance(this->max_correspondence_distance);
-    icp.setEuclideanFitnessEpsilon(this->euclidean_fitness);
-    icp.setRANSACOutlierRejectionThreshold(this->ransac_rejection_threshold);
+    //icp.setEuclideanFitnessEpsilon(this->euclidean_fitness);
+    //icp.setRANSACOutlierRejectionThreshold(this->ransac_rejection_threshold);
 
     icp.align(*target_cloud);
 


### PR DESCRIPTION
Some issues still persist but for the most part it works. >10 pointclouds causes registration to take excessively long time due to dense target cloud. Correspondences = target_points*source_points. Corrected privacy settings of getters and setters.