### PR TITLE
Reg conf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,12 @@ project(3DCopy)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(PCL 1.3 REQUIRED)
-include_directories(${PCL_INCLUDE_DIRS})
+find_package(Boost 1.40 COMPONENTS program_options REQUIRED)
+include_directories(${PCL_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
 set(SOURCE_FILES src/main.cpp src/Cli.cpp src/Mesh.cpp src/Registration.cpp)
 add_executable(3DCopy ${SOURCE_FILES})
 
-target_link_libraries(3DCopy ${PCL_LIBRARIES})
+target_link_libraries(3DCopy ${PCL_LIBRARIES} ${Boost_LIBRARIES})

--- a/include/Cli.h
+++ b/include/Cli.h
@@ -6,11 +6,13 @@
 #include <vector>
 #include <boost/filesystem.hpp>
 #include <pcl/io/pcd_io.h>
+#include <boost/program_options.hpp>
 
 #ifndef INC_3DCOPY_CLI_H
 #define INC_3DCOPY_CLI_H
 
 namespace fs = boost::filesystem;
+namespace po = boost::program_options;
 
 class Cli {
     public:
@@ -27,14 +29,15 @@ class Cli {
         bool verbose = false;
 
         // Methods
+        void print_help(po::options_description options, char **argv);
         int parse_arguments(int argc, char* argv[]);
-        int parse_option(std::string option);
         int read_dir(fs::path path);
         void print_input();
         void add_source(fs::path path);
         pcl::PointCloud<pcl::PointXYZ>::Ptr register_point_clouds();
         void save_point_cloud(const pcl::PointCloud<pcl::PointXYZ>::Ptr point_cloud);
         void save_mesh(const pcl::PolygonMesh polygon_mesh);
+        void load_values(po::variables_map vm);
 };
 
 

--- a/include/Cli.h
+++ b/include/Cli.h
@@ -20,11 +20,11 @@ class Cli {
 
     private:
         // Fields
-        std::vector<fs::path> sources;
+        std::vector<fs::path> sources = std::vector<fs::path>();
         std::string output_filename;
-        bool mesh_only;
-        bool register_only;
-        bool verbose;
+        bool mesh_only = false;
+        bool register_only = false;
+        bool verbose = false;
 
         // Methods
         int parse_arguments(int argc, char* argv[]);

--- a/include/Cli.h
+++ b/include/Cli.h
@@ -27,6 +27,10 @@ class Cli {
         bool mesh_only = false;
         bool register_only = false;
         bool verbose = false;
+        double max_correspondence_distance = 15;    //Maximum distance allowed between point a in cloud x and
+                                                    // point a in cloud y
+        int max_iterations = 100;                   //Force the ICP Algorithm to stop after max_iterations
+        double transformation_epsilon = 1e-7;       //How much ICP is allowed to move source in one iteration
 
         // Methods
         void print_help(po::options_description options, char **argv);

--- a/include/Cli.h
+++ b/include/Cli.h
@@ -29,7 +29,7 @@ class Cli {
         bool verbose = false;
         double max_correspondence_distance = 15;    //Maximum distance allowed between point a in cloud x and
                                                     // point a in cloud y
-        int max_iterations = 100;                   //Force the ICP Algorithm to stop after max_iterations
+        unsigned int max_iterations = 100;          //Force the ICP Algorithm to stop after max_iterations
         double transformation_epsilon = 1e-7;       //How much ICP is allowed to move source in one iteration
 
         // Methods

--- a/include/Registration.h
+++ b/include/Registration.h
@@ -24,8 +24,8 @@ private:
     bool icp_converged;
     double max_correspondence_distance = 15;    //Maximum distance allowed between point a in cloud x and
                                                 // point a in cloud y
-    int max_iterations = 100;                   //Force the ICP Algorithm to stop after max_iterations;
-    double transformation_epsilon = 1e-7;       //How much ICP is allowed to move source in one iteration;
+    int max_iterations = 100;                   //Force the ICP Algorithm to stop after max_iterations
+    double transformation_epsilon = 1e-7;       //How much ICP is allowed to move source in one iteration
     bool verbose = false;
 
 

--- a/include/Registration.h
+++ b/include/Registration.h
@@ -10,6 +10,18 @@ class Registration {
 public:
     //Methods
     Cloud::Ptr register_point_clouds(std::vector<Cloud::Ptr> input_pclouds);
+    void set_max_iterations(int iter);
+    int get_max_iterations();
+    void set_max_correspondence_distance(double distance);
+    double get_max_correspondence_distance();
+    void set_transformation_epsilon(double epsilon);
+    double get_transformation_epsilon();
+    void set_verbose_mode(bool mode);
+    bool get_verbose_mode();
+    void set_ransac_threshold(double threshold);
+    double get_ransac_threshold();
+    void set_euclidean_fitness(double epsilon);
+    double get_euclidean_fitness();
 
 private:
     //Data fields
@@ -25,18 +37,6 @@ private:
     //Methods
     Cloud::Ptr add_point_cloud_to_target(Cloud::Ptr target_cloud, Cloud::Ptr source_cloud);
     bool has_converged();
-    void set_max_iterations(int iter);
-    int get_max_iterations();
-    void set_max_correspondence_distance(double distance);
-    double get_max_correspondence_distance();
-    void set_transformation_epsilon(double epsilon);
-    double get_transformation_epsilon();
-    void set_verbose_mode(bool mode);
-    bool get_verbose_mode();
-    void set_ransac_threshold(double threshold);
-    double get_ransac_threshold();
-    void set_euclidean_fitness(double epsilon);
-    double get_euclidean_fitness();
 };
 
 

--- a/include/Registration.h
+++ b/include/Registration.h
@@ -10,12 +10,12 @@ class Registration {
 public:
     //Methods
     Cloud::Ptr register_point_clouds(std::vector<Cloud::Ptr> input_pclouds);
-    void set_max_iterations(int iter);
-    int get_max_iterations();
+    void set_max_iterations(unsigned int iter);
+    unsigned int get_max_iterations();
     void set_max_correspondence_distance(double distance);
-    double get_max_correspondence_distance();
+    unsigned double get_max_correspondence_distance();
     void set_transformation_epsilon(double epsilon);
-    double get_transformation_epsilon();
+    unsigned double get_transformation_epsilon();
     void set_verbose_mode(bool mode);
     bool get_verbose_mode();
 
@@ -24,7 +24,7 @@ private:
     bool icp_converged;
     double max_correspondence_distance = 15;    //Maximum distance allowed between point a in cloud x and
                                                 // point a in cloud y
-    int max_iterations = 100;                   //Force the ICP Algorithm to stop after max_iterations
+    unsigned int max_iterations = 100;                   //Force the ICP Algorithm to stop after max_iterations
     double transformation_epsilon = 1e-7;       //How much ICP is allowed to move source in one iteration
     bool verbose = false;
 

--- a/include/Registration.h
+++ b/include/Registration.h
@@ -13,9 +13,9 @@ public:
     void set_max_iterations(unsigned int iter);
     unsigned int get_max_iterations();
     void set_max_correspondence_distance(double distance);
-    unsigned double get_max_correspondence_distance();
+    double get_max_correspondence_distance();
     void set_transformation_epsilon(double epsilon);
-    unsigned double get_transformation_epsilon();
+    double get_transformation_epsilon();
     void set_verbose_mode(bool mode);
     bool get_verbose_mode();
 

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -13,12 +13,7 @@ namespace fs = boost::filesystem;
 /**
  *  Default constructor that initializes a few private values.
  */
-Cli::Cli() {
-    mesh_only = false;
-    register_only = false;
-    verbose = false;
-    sources = std::vector<fs::path>();
-}
+Cli::Cli() {}
 
 /**
  * The main method that takes in the arguments and runs the program. Right now it only prints the inputed arguments but it's here

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -6,9 +6,11 @@
 #include "../include/Mesh.h"
 #include "../include/Registration.h"
 #include <pcl/io/vtk_lib_io.h>
+#include <boost/program_options.hpp>
 
 typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
 namespace fs = boost::filesystem;
+namespace po = boost::program_options;
 
 /**
  *  Default constructor that initializes a few private values.
@@ -208,6 +210,9 @@ void Cli::add_source(fs::path path) {
  */
 PointCloud::Ptr Cli::register_point_clouds() {
     Registration registration = Registration();
+
+    registration.set_verbose_mode(verbose);
+
     std::vector<PointCloud::Ptr> point_clouds;
 
     for (auto it=sources.begin(); it!=sources.end(); ++it) {

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -262,6 +262,11 @@ void Cli::save_mesh(const pcl::PolygonMesh polygon_mesh) {
     std::cout << "Saved mesh to " << ss.str() << std::endl;
 }
 
+/**
+ * Prints the help message.
+ * @param options The options to be printed in the message.
+ * @param argv List of arguments passed from the CLI used to get the command used.
+ */
 void Cli::print_help(po::options_description options, char **argv) {
     std::cout << "Usage: " << argv[0] << " [options] source1:source2... output_filename" << std::endl;
     std::cout << "source are the .pcd files to be registered and output_filename is the filename of the output "

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -25,9 +25,9 @@ Cli::Cli() {}
  */
 int Cli::main(int argc, char **argv) {
 
-    Mesh mesh = Mesh();
-
     parse_arguments(argc, argv);
+
+    Mesh mesh = Mesh();
 
     if (mesh_only && !sources.empty()) {
         PointCloud::Ptr point_cloud_ptr (new PointCloud);

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -98,8 +98,8 @@ int Cli::parse_arguments(int argc, char **argv) {
             ("verbose,v", "run the program in verbose mode.")
             ("mesh-only,m", "only mesh the pcd file.")
             ("register-only,r", "only register the pcd files.")
-            ("max-corr-dist,d", po::value<double>(), "Maximum distance allowed between points in different clouds.")
-            ("max-iterations,i", po::value<int>(), "Maximum number of iterations ICP are allowed to do.");
+            ("max-corr-dist,d", po::value<double>(), "Maximum distance allowed between points in different clouds. (>0)")
+            ("max-iterations,i", po::value<int>(), "Maximum number of iterations ICP are allowed to do. (>0)");
 
     po::options_description filenames("Input and output files");
     filenames.add_options()
@@ -163,11 +163,11 @@ void Cli::load_values(po::variables_map vm) {
         register_only = mesh_only = false;
     }
 
-    if (vm.count("max-corr-dist")) {
+    if (vm.count("max-corr-dist") && vm["max-corr-dist"].as<double>() > 0) {
         max_correspondence_distance = vm["max-corr-dist"].as<double>();
     }
 
-    if (vm.count("max-iterations")) {
+    if (vm.count("max-iterations") && vm["max-iterations"].as<int>() > 0) {
         max_iterations = vm["max-iterations"].as<int>();
     }
 

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -168,7 +168,7 @@ void Cli::load_values(po::variables_map vm) {
     }
 
     if (vm.count("max-iterations") && vm["max-iterations"].as<int>() > 0) {
-        max_iterations = vm["max-iterations"].as<int>();
+        max_iterations = (unsigned int)vm["max-iterations"].as<int>();
     }
 
     if (vm.count("filenames")) {
@@ -228,6 +228,7 @@ PointCloud::Ptr Cli::register_point_clouds() {
     registration.set_verbose_mode(verbose);
     registration.set_max_correspondence_distance(max_correspondence_distance);
     registration.set_max_iterations(max_iterations);
+    registration.set_transformation_epsilon(transformation_epsilon);
 
     std::vector<PointCloud::Ptr> point_clouds;
 

--- a/src/Cli.cpp
+++ b/src/Cli.cpp
@@ -132,7 +132,7 @@ int Cli::parse_arguments(int argc, char **argv) {
     load_values(vm);
 
     if (sources.empty()) {
-        std::cout << "No sources fund" << std::endl;
+        std::cout << "No sources found" << std::endl;
         print_help(options, argv);
         return 3;
     }

--- a/src/Registration.cpp
+++ b/src/Registration.cpp
@@ -43,9 +43,6 @@ Registration::add_point_cloud_to_target(Cloud::Ptr target_cloud, Cloud::Ptr sour
     // Parameters for the ICP algorithm
     icp.setInputTarget(source_cloud);
     icp.setInputSource(target_cloud);
-    std::cout << "verbose: " << verbose << std::endl;
-    std::cout << "max iterations: " << max_iterations << std::endl;
-    std::cout << "max corr dist: " << max_correspondence_distance << std::endl;
     icp.setMaximumIterations(this->max_iterations);
     icp.setTransformationEpsilon(this->transformation_epsilon);
     icp.setMaxCorrespondenceDistance(this->max_correspondence_distance);

--- a/src/Registration.cpp
+++ b/src/Registration.cpp
@@ -116,22 +116,3 @@ bool
 Registration::get_verbose_mode(){
     return this->verbose;
 }
-void
-Registration::set_euclidean_fitness(double epsilon){
-    this->euclidean_fitness = epsilon;
-}
-
-double
-Registration::get_euclidean_fitness(){
-    return this->euclidean_fitness;
-}
-
-void
-Registration::set_ransac_threshold(double threshold){
-    this->ransac_rejection_threshold = threshold;
-}
-
-double
-Registration::get_ransac_threshold(){
-    return this->ransac_rejection_threshold;
-}

--- a/src/Registration.cpp
+++ b/src/Registration.cpp
@@ -43,6 +43,9 @@ Registration::add_point_cloud_to_target(Cloud::Ptr target_cloud, Cloud::Ptr sour
     // Parameters for the ICP algorithm
     icp.setInputTarget(source_cloud);
     icp.setInputSource(target_cloud);
+    std::cout << "verbose: " << verbose << std::endl;
+    std::cout << "max iterations: " << max_iterations << std::endl;
+    std::cout << "max corr dist: " << max_correspondence_distance << std::endl;
     icp.setMaximumIterations(this->max_iterations);
     icp.setTransformationEpsilon(this->transformation_epsilon);
     icp.setMaxCorrespondenceDistance(this->max_correspondence_distance);

--- a/src/Registration.cpp
+++ b/src/Registration.cpp
@@ -82,20 +82,24 @@ Registration::has_converged(){
 
 void
 Registration::set_max_correspondence_distance(double distance){
-    this->max_correspondence_distance = distance;
+    if (distance > 0) {
+        this->max_correspondence_distance = distance;
+    }
 }
 
 void
-Registration::set_max_iterations(int iter){
+Registration::set_max_iterations(unsigned int iter){
     this->max_iterations = iter;
 }
 
 void
 Registration::set_transformation_epsilon(double epsilon){
-    this->transformation_epsilon = epsilon;
+    if (epsilon > 0) {
+        this->transformation_epsilon = epsilon;
+    }
 }
 
-int
+unsigned int
 Registration::get_max_iterations(){
     return this->max_iterations;
 }


### PR DESCRIPTION
Skrivit om hela argument parsing delen. Nu använder vi boosts program_options bibliotek. Jag har också lagt till max iterations och max correspondance distance som parametrar. Transformation epsilon blev bökigt då biblioteket inte kan parsar 1-e7 som en int. Tänker att man kan lägga till det senare. 

När det kommer till testning så har jag testat positiva och negativa värden samt att skicka in options lite huller om buller. Detta samt felaktiga options hanteras bra. Skulle säkert behöva testas mera och mer systematiskt men jag vet inte riktigt hur. Tänker att vi tar det vid systemtest vilket vi borde kunna ha nu för man kan köra programmet hela vägen.