### PR TITLE
Mesh2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.7.1)
 project(3DCopy)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -65,16 +65,25 @@ void
 Mesh::poisson_reconstruction(pcl::PointCloud<pcl::PointNormal>::Ptr point_cloud, pcl::PolygonMesh& mesh)
 {
 
+    int depth = 11;
+    int solver_divide = 7;
+    int iso_divide = 10;
+    int samples_per_node = 1;
+    float point_weight = 4.0f;
+
     std::cout << "Begin poisson surface reconstruction" << std::endl;
     // Initialize poisson reconstruction
     pcl::Poisson<pcl::PointNormal> poisson;
 
     /*
-     * Set the maximum depth of the tree used in Poisson surface reconstruction.
-     * A higher value means more iterations which could lead to better results but
-     * it is also more computationally heavy.
-     */
-    poisson.setDepth(10);
+    * Set the maximum depth of the tree used in Poisson surface reconstruction.
+    * A higher value means more iterations which could lead to better results but
+    * it is also more computationally heavy.
+    */
+    poisson.setDepth(depth);
+    poisson.setSolverDivide(solver_divide);
+    poisson.setPointWeight(point_weight);
+    poisson.setSamplesPerNode(samples_per_node);
     poisson.setInputCloud(point_cloud);
 
     // Perform the Poisson surface reconstruction algorithm
@@ -101,6 +110,8 @@ Mesh::mesh(const PointCloud::Ptr point_cloud)
     // Point cloud to mesh reconstruction
     pcl::PolygonMesh mesh;
     poisson_reconstruction(cloud_with_normals, mesh);
+
+
 
     return mesh;
 }


### PR DESCRIPTION
Jag har ändrat cmake versionen till 3.7.1 (clion kör den versionen) i CMakeLists.txt. Detta gör att varningarna som genereras av Boost försvinner (iaf för mig).

I meshningen har jag lagt till lite parametrar och värden på dessa som gör att meshen ser så bra ut som möjligt (vad jag tycker). Dessa värden kan behövas modifieras för bättre resultat.
Förklaring vad varje parameter gör är taget från PCLs doc. och alla är inte så enkla att förstå.