### PR TITLE
Installationsscript

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.7.1)
 project(3DCopy)
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_BUILD_TYPE Release)
+#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O1")
+
 find_package(PCL 1.3 REQUIRED)
 find_package(Boost 1.40 COMPONENTS program_options filesystem log REQUIRED)
 
@@ -19,4 +22,6 @@ set(SOURCE_FILES src/main.cpp src/Cli.cpp src/Mesh.cpp src/Registration.cpp src/
 
 add_executable(3DCopy ${SOURCE_FILES})
 
-target_link_libraries(3DCopy ${PCL_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(3DCopy ${PCL_LIBRARIES} ${Boost_LIBRARIES} -lpthread)
+
+install(TARGETS 3DCopy DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(3DCopy)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BUILD_TYPE Release)
-#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O1")
 
 find_package(PCL 1.3 REQUIRED)
 find_package(Boost 1.40 COMPONENTS program_options filesystem log REQUIRED)
@@ -22,6 +21,6 @@ set(SOURCE_FILES src/main.cpp src/Cli.cpp src/Mesh.cpp src/Registration.cpp src/
 
 add_executable(3DCopy ${SOURCE_FILES})
 
-target_link_libraries(3DCopy ${PCL_LIBRARIES} ${Boost_LIBRARIES} -lpthread)
+target_link_libraries(3DCopy ${PCL_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS 3DCopy DESTINATION bin)

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Installing dependecies"
 {
-    # Install basic build dependencies
-    apt-get install make g++ libboost-all-dev -y
+    # Add PPA for installing PCL
+    sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
+
+    # Install basic build dependencies and Boost
+    sudo apt-get update
+    sudo apt-get install make g++ libboost-all-dev -y
 
     # Install PCL
-    add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
-    apt-get update
-    apt-get install libpcl-all -y
+    sudo apt-get install libpcl-all -y
 
 } > /dev/null 2>&1
 
@@ -18,7 +20,6 @@ cd build
 
 echo "Downloading cmake version 3.8.1"
 {
-    echo "hej"
     # Download recent version of cmake
     wget https://cmake.org/files/v3.8/cmake-3.8.1-Linux-x86_64.sh
     chmod +x cmake-3.8.1-Linux-x86_64.sh
@@ -30,10 +31,10 @@ echo "Downloading cmake version 3.8.1"
 echo "Generating makefiles with cmake"
 {
     cmake-3.8.1-Linux-x86_64/bin/cmake ..
-}
+} > /dev/null 2>&1
 
 echo "Running make"
-make -j4
-make install
+make -j4 > /dev/null 2>&1
+sudo make install
 
 echo "Done"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+echo "Installing dependecies"
+{
+    # Install basic build dependencies
+    apt-get install make g++ libboost-all-dev -y
+
+    # Install PCL
+    add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
+    apt-get update
+    apt-get install libpcl-all -y
+
+} > /dev/null 2>&1
+
+echo "Creating build dir"
+mkdir -p build
+cd build
+
+echo "Downloading cmake version 3.8.1"
+{
+    echo "hej"
+    # Download recent version of cmake
+    wget https://cmake.org/files/v3.8/cmake-3.8.1-Linux-x86_64.sh
+    chmod +x cmake-3.8.1-Linux-x86_64.sh
+    ./cmake-3.8.1-Linux-x86_64.sh --include-subdir
+    rm cmake-3.8.1-Linux-x86_64.sh
+
+} > /dev/null 2>&1
+
+echo "Generating makefiles with cmake"
+{
+    cmake-3.8.1-Linux-x86_64/bin/cmake ..
+}
+
+echo "Running make"
+make -j4
+make install
+
+echo "Done"

--- a/install.sh
+++ b/install.sh
@@ -2,15 +2,23 @@
 
 echo "Installing dependecies"
 {
-    # Add PPA for installing PCL
-    sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
+    # Find which version of Ubuntu is running
+    source /etc/lsb-release
+    if [ DISTRIB_RELEASE == "14.04" ]; then 
+	# Add PPA for installing PCL
+	sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
+	sudo apt-get update
 
-    # Install basic build dependencies and Boost
-    sudo apt-get update
+	# Install PCL
+	sudo apt-get install libpcl-all -y
+    else
+	# Probably later version, just install PCL
+	sudo apt-get update
+	sudo apt-get install libpcl-dev
+    fi
+
+    # Install basic build dependencies and Boost	
     sudo apt-get install make g++ libboost-all-dev -y
-
-    # Install PCL
-    sudo apt-get install libpcl-all -y
 
 } > /dev/null 2>&1
 

--- a/install.sh
+++ b/install.sh
@@ -2,15 +2,23 @@
 
 echo "Installing dependecies"
 {
-    # Add PPA for installing PCL
-    sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
+    # Find which version of Ubuntu is running
+    source /etc/lsb-release
+    if [ DISTRIB_RELEASE == "14.04" ]; then 
+	# Add PPA for installing PCL
+	sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
+	sudo apt-get update
 
-    # Install basic build dependencies and Boost
-    sudo apt-get update
+	# Install PCL
+	sudo apt-get install libpcl-all -y
+    else
+	# Probably later version, just install PCL
+	sudo apt-get update
+	sudo apt-get install libpcl-dev -y
+    fi
+
+    # Install basic build dependencies and Boost	
     sudo apt-get install make g++ libboost-all-dev -y
-
-    # Install PCL
-    sudo apt-get install libpcl-all -y
 
 } > /dev/null 2>&1
 

--- a/install.sh
+++ b/install.sh
@@ -28,12 +28,12 @@ echo "Downloading cmake version 3.8.1"
 
 } > /dev/null 2>&1
 
-echo "Generating makefiles with cmake"
+echo "Generating makefiles"
 {
     cmake-3.8.1-Linux-x86_64/bin/cmake ..
 } > /dev/null 2>&1
 
-echo "Running make"
+echo "Building 3DCopy"
 make -j4 > /dev/null 2>&1
 sudo make install
 


### PR DESCRIPTION
Nu finns ett fungerande installationsscript för 3DCopy. För att installera 3DCopy är det bara att clona repositoryt, ställa sig i mappen och köra ./install.sh. Scriptet installerar även 3DCopy-executablen till /usr/local/bin så programmet går att köra från var som helst i systemet.

Testat på en helt clean Ubuntu 14.04 virtual machine och det fungerade utan problem.