### PR TITLE
Fixat bugg i scriptet för Ubuntu 16.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ link_directories(${PCL_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 add_definitions(-DBOOST_LOG_DYN_LINK)
 
+list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
+
 set(SOURCE_FILES src/main.cpp src/Cli.cpp src/Mesh.cpp src/Registration.cpp src/Slicer.cpp)
 
 add_executable(3DCopy ${SOURCE_FILES})

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ echo "Installing dependecies"
     else
 	# Probably later version, just install PCL
 	sudo apt-get update
-	sudo apt-get install libpcl-dev -y
+	sudo apt-get install libpcl-dev libproj-dev -y
     fi
 
     # Install basic build dependencies and Boost	


### PR DESCRIPTION
Fixade en liten bugg i scriptet så nu fungerar det att installera på Ubuntu 16.04 också vilket kan vara bra. Även om vi endast "officiellt" stöder 14.04 kan det vara bra att det fungerar på 16.04 också då det var väldigt lite extra jobb.

Buggen berodde på att PCL-paketen i olika Ubuntu-versioner fungerar lite olika.